### PR TITLE
Discretizer ameva and small fixes

### DIFF
--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/AbstractDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/AbstractDiscretizer.java
@@ -1,6 +1,7 @@
 package de.viadee.xai.anchor.adapter.tabular.discretizer;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -11,7 +12,7 @@ import java.util.List;
 public abstract class AbstractDiscretizer implements Discretizer {
     private final boolean isSupervised;
 
-    private List<DiscretizationTransition> discretizationTransitions;
+    private List<DiscretizationTransition> discretizationTransitions = new ArrayList<>();
 
     /**
      * Constructs the instance
@@ -66,7 +67,7 @@ public abstract class AbstractDiscretizer implements Discretizer {
         }
 
         // In case all origins are numeric we need to set open lower and upper boundaries
-        if (this.discretizationTransitions.size() > 1 && this.discretizationTransitions.stream()
+        if (!this.discretizationTransitions.isEmpty() && this.discretizationTransitions.stream()
                 .allMatch(d -> d.getDiscretizationOrigin() instanceof NumericDiscretizationOrigin)) {
             DiscretizationTransition minDisc = this.discretizationTransitions.get(0);
             DiscretizationTransition maxDisc = this.discretizationTransitions.get(0);

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/AbstractDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/AbstractDiscretizer.java
@@ -1,7 +1,6 @@
 package de.viadee.xai.anchor.adapter.tabular.discretizer;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -12,7 +11,7 @@ import java.util.List;
 public abstract class AbstractDiscretizer implements Discretizer {
     private final boolean isSupervised;
 
-    private List<DiscretizationTransition> discretizationTransitions = new ArrayList<>();
+    private List<DiscretizationTransition> discretizationTransitions;
 
     /**
      * Constructs the instance

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/Interval.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/Interval.java
@@ -15,14 +15,14 @@ public final class Interval {
     private final int end;
     private final int size;
     private final int[] classDist;
-    private final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs;
+    private final List<AbstractMap.SimpleImmutableEntry<Double, Double>> keyValuePairs;
 
     /**
      * @param begin         begin index of Interval
      * @param end           end index of Interval
      * @param keyValuePairs list of all values, only used to determine class distribution in interval
      */
-    public Interval(int begin, int end, List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs) {
+    public Interval(int begin, int end, List<AbstractMap.SimpleImmutableEntry<Double, Double>> keyValuePairs) {
         Double[] targetValues = keyValuePairs.stream().map(AbstractMap.SimpleImmutableEntry::getValue).sorted().distinct().toArray(Double[]::new);
         this.classDist = new int[targetValues.length];
         this.begin = begin;
@@ -68,9 +68,9 @@ public final class Interval {
 
     private double medianIndexValue() {
         if (getSize() % 2 == 0) {
-            return (keyValuePairs.get(end + 1 - getSize() / 2).getKey().doubleValue() + keyValuePairs.get(end + 1 - getSize() / 2 - 1).getKey().doubleValue()) / 2;
+            return (keyValuePairs.get(end + 1 - getSize() / 2).getKey() + keyValuePairs.get(end + 1 - getSize() / 2 - 1).getKey()) / 2;
         } else {
-            return keyValuePairs.get(end - getSize() / 2).getKey().doubleValue();
+            return keyValuePairs.get(end - getSize() / 2).getKey();
         }
     }
 }

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/Interval.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/Interval.java
@@ -4,10 +4,12 @@ import java.util.AbstractMap;
 import java.util.List;
 import java.util.stream.IntStream;
 
+/**
+ * Interval class for Discretization methods with begin and end index to determine class distribution
+ * can be transformed to DiscretizerTransitions
+ */
 public final class Interval {
-    /**
-     * private Interval class for FUSINTER Method with begin and end index to determine class distribution
-     */
+
 
     private final int begin;
     private final int end;
@@ -68,7 +70,7 @@ public final class Interval {
         if (getSize() % 2 == 0) {
             return (keyValuePairs.get(end + 1 - getSize() / 2).getKey().doubleValue() + keyValuePairs.get(end + 1 - getSize() / 2 - 1).getKey().doubleValue()) / 2;
         } else {
-            return keyValuePairs.get(end + 1 - getSize() / 2).getKey().doubleValue();
+            return keyValuePairs.get(end - getSize() / 2).getKey().doubleValue();
         }
     }
 }

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/Interval.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/Interval.java
@@ -1,0 +1,74 @@
+package de.viadee.xai.anchor.adapter.tabular.discretizer;
+
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.stream.IntStream;
+
+public final class Interval {
+    /**
+     * private Interval class for FUSINTER Method with begin and end index to determine class distribution
+     */
+
+    private final int begin;
+    private final int end;
+    private final int size;
+    private final int[] classDist;
+    private final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs;
+
+    /**
+     * @param begin         begin index of Interval
+     * @param end           end index of Interval
+     * @param keyValuePairs list of all values, only used to determine class distribution in interval
+     */
+    public Interval(int begin, int end, List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs) {
+        Double[] targetValues = keyValuePairs.stream().map(AbstractMap.SimpleImmutableEntry::getValue).sorted().distinct().toArray(Double[]::new);
+        this.classDist = new int[targetValues.length];
+        this.begin = begin;
+        this.end = end;
+        this.size = end - begin + 1;
+        this.keyValuePairs = keyValuePairs;
+
+        for (int t = 0; t < targetValues.length; t++) {
+            final int finalT = t;
+            classDist[t] = (int) IntStream.rangeClosed(begin, end)
+                    .mapToObj(i -> keyValuePairs.get(i).getValue())
+                    .filter(i -> Double.compare(i, targetValues[finalT]) == 0)
+                    .count();
+        }
+    }
+
+    public int getBegin() {
+        return begin;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public int[] getClassDist() {
+        return classDist;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    /**
+     * @return the interval as a {@link DiscretizationTransition}
+     */
+    public DiscretizationTransition toDiscretizationTransition() {
+        return new DiscretizationTransition(new NumericDiscretizationOrigin(
+                keyValuePairs.get(begin).getKey(),
+                keyValuePairs.get(end).getKey()),
+                medianIndexValue()
+        );
+    }
+
+    private double medianIndexValue() {
+        if (getSize() % 2 == 0) {
+            return (keyValuePairs.get(end + 1 - getSize() / 2).getKey().doubleValue() + keyValuePairs.get(end + 1 - getSize() / 2 - 1).getKey().doubleValue()) / 2;
+        } else {
+            return keyValuePairs.get(end + 1 - getSize() / 2).getKey().doubleValue();
+        }
+    }
+}

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/NumericDiscretizationOrigin.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/NumericDiscretizationOrigin.java
@@ -1,7 +1,5 @@
 package de.viadee.xai.anchor.adapter.tabular.discretizer;
 
-import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationOrigin;
-import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationType;
 import de.viadee.xai.anchor.adapter.tabular.util.FormatTools;
 
 import java.io.Serializable;

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
@@ -104,16 +104,7 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 
         Collections.sort(actualCutPoints);
 
-        int lowerBoundary = 0;
-        int z = 0;
-        List<Interval> evaluatedIntervals = new ArrayList<>();
-        for(Double cp: actualCutPoints) {
-            while(keyValuePairs.get(z).getKey().doubleValue() < cp && z < keyValuePairs.size()) {
-                z++;
-            }
-            evaluatedIntervals.add(new Interval(lowerBoundary, z, keyValuePairs));
-            z = lowerBoundary = z + 1;
-        }
+        List<Interval> evaluatedIntervals = getIntervalsFromCutPoints(actualCutPoints);
 //        Output: Discretization scheme L(k).
         return evaluatedIntervals.stream().map(Interval::toDiscretizationTransition).collect(Collectors.toList());
     }
@@ -142,20 +133,7 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
         List<Double> potentialCutPoints = new ArrayList<>(actualCutPoints);
         potentialCutPoints.add(potentialCutPoint);
         Collections.sort(potentialCutPoints);
-        List<Interval> intervals = new ArrayList<>();
-
-        int lowerBoundary = 0;
-        int z = 0;
-        for(Double cp: potentialCutPoints) {
-            while(keyValuePairs.get(z).getKey().doubleValue() < cp && z < keyValuePairs.size() - 1) {
-                z++;
-            }
-            intervals.add(new Interval(lowerBoundary, z, keyValuePairs));
-            z = lowerBoundary = z + 1;
-        }
-        if(intervals.get(intervals.size() -1).getEnd() != keyValuePairs.get(keyValuePairs.size() -1).getKey().doubleValue()) {
-            intervals.add(new Interval(lowerBoundary, keyValuePairs.size() - 1, keyValuePairs));
-        }
+        List<Interval> intervals = getIntervalsFromCutPoints(potentialCutPoints);
 
         double chiSquared = 0.0;
         for(int i = 0; i < targetValues.length; i++){
@@ -169,5 +147,22 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 
         double ameva = chiSquared / (intervals.size() * (targetValues.length  - 1)) /*k * (l - 1)*/;
         return ameva;
+    }
+
+    private List<Interval> getIntervalsFromCutPoints(List<Double> cutPoints) {
+        int lowerBoundary = 0;
+        int z = 0;
+        List<Interval> createdIntervals = new ArrayList<>();
+        for(Double cp: cutPoints) {
+            while(keyValuePairs.get(z).getKey().doubleValue() < cp && z < keyValuePairs.size()) {
+                z++;
+            }
+            createdIntervals.add(new Interval(lowerBoundary, z, keyValuePairs));
+            z = lowerBoundary = z + 1;
+        }
+        if(createdIntervals.get(createdIntervals.size() -1).getEnd() != keyValuePairs.get(keyValuePairs.size() -1).getKey().doubleValue()) {
+            createdIntervals.add(new Interval(lowerBoundary, keyValuePairs.size() - 1, keyValuePairs));
+        }
+        return createdIntervals;
     }
 }

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
@@ -53,7 +53,7 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 
         keyValuePairs = IntStream.range(0, values.length)
                 .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>((Double) values[i], labels[i]))
-                .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue()))
+                .sorted(Comparator.comparing(AbstractMap.SimpleImmutableEntry::getKey))
                 .collect(Collectors.toList());
 
         bCutPoints = IntStream.range(1, values.length)
@@ -143,7 +143,7 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
         int z = 0;
         List<Interval> createdIntervals = new ArrayList<>();
         for(Double cp: cutPoints) {
-            while(keyValuePairs.get(z).getKey() < cp && z < keyValuePairs.size()) {
+            while(z < keyValuePairs.size() && keyValuePairs.get(z).getKey() < cp) {
                 z++;
             }
             createdIntervals.add(new Interval(lowerBoundary, z -1, keyValuePairs));

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
@@ -63,14 +63,13 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 
         double globalAmeva = 0.0;
         double ameva = createNewCutPoint(globalAmeva);
-        int k = 1;
 
         // ameva will be above globalAmeva until the (local) maximum of the contingency coefficient is found.
-        // to prevent an infinite looping in while loop, k is introduced as an exit condition, to break the loop if needed
-        while(ameva > globalAmeva && k < keyValuePairs.size()){
+        // to prevent an infinite looping in while loop, length of potential cut points is tested for emptiness, to break the loop if
+        // all potential cut points have been added.
+        while(ameva > globalAmeva && !bCutPoints.isEmpty()){
             globalAmeva = ameva;
             ameva = createNewCutPoint(globalAmeva);
-            k++;
         }
 
         if(actualCutPoints.isEmpty()) {

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
@@ -3,7 +3,6 @@ package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
 import de.viadee.xai.anchor.adapter.tabular.discretizer.AbstractDiscretizer;
 import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
 import de.viadee.xai.anchor.adapter.tabular.discretizer.Interval;
-import de.viadee.xai.anchor.adapter.tabular.discretizer.NumericDiscretizationOrigin;
 
 import java.io.Serializable;
 import java.util.*;
@@ -12,13 +11,13 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Implementation of the FUSINTER discretization algorithm described by [Gonzales-Abril, Cuberos, Velasco, Ortega 2009]
+ * Implementation of the Ameva discretization algorithm described by [Gonzales-Abril, Cuberos, Velasco, Ortega 2009]
  */
 public class AmevaDiscretizer extends AbstractDiscretizer {
 
     private Double[] targetValues;
     private long[] targetValueDistribution;
-    private List<Double> B = new ArrayList<>();
+    private List<Double> bCutPoints = new ArrayList<>();
     private List<Double> actualCutPoints = new ArrayList<>();
     private List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs;
 
@@ -29,91 +28,68 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
         super(true);
     }
 
+    /**
+     *
+     * Implementation of Ameva, 1. sort values and get all CutPoints, 2. Consecutively add new cut points and determine
+     * Ameva value (variation of contingency coefficient) of the tentative cut points. Get best cut point of this
+     * iteration. If the ameva value does not increase with new cut points break and return Discretization
+     *
+     * @param labels Array of Doubles, classifications of instances
+     * @param values Array of Numbers expected. Ameva is only possible with continuous variables
+     * @return list of DiscretizationTransition determined to have the highest Ameva value
+     */
     @Override
     protected List<DiscretizationTransition> fitCreateTransitions(Serializable[] values, Double[] labels) {
 
         if (Stream.of(values).anyMatch(v -> !(v instanceof Number))) {
             throw new IllegalArgumentException("Only numeric values allowed for this discretizer");
         }
-        List<DiscretizationTransition> discretizationTransitions = new ArrayList<>();;
         targetValues = Arrays.stream(labels).sorted().distinct().toArray(Double[]::new);
         targetValueDistribution = new long[targetValues.length];
         for(int i = 0; i < targetValues.length; i++) {
             int finalI = i;
             targetValueDistribution[i] = Arrays.stream(labels).filter(label -> label.equals(targetValues[finalI])).count();
         }
-//        For every continuous variable (X_i) do:
-//
-//        Step 1: Initialization of the candidate interval
-//        boundaries and the initial discretization scheme.
-
-//        1.1 Find the maximum (d_k) and minimum (d_0) values of X_i.
-//        1.2 Form a set of all distinct values of X_i, in ascending
-//        order, and initialize all possible interval
-//        boundaries B with the minimum, maximum and all the
-//        midpoints of all the adjacent pairs in the set.
 
         keyValuePairs = IntStream.range(0, values.length)
                 .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>((Number) values[i], labels[i]))
                 .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue()))
                 .collect(Collectors.toList());
 
-        B = IntStream.range(1, values.length)
+        bCutPoints = IntStream.range(1, values.length)
                 .mapToObj(i -> ((Double) values[i] + (Double) values[i-1] )/ 2)
                 .sorted().distinct()
                 .collect(Collectors.toList());
 
-//        1.3 Set the initial discretization scheme to
-//        L:{[d_0, d_k]}, set GlobalAmeva = 0.
-        Number d_0 = keyValuePairs.get(0).getValue();
-        Number d_k = keyValuePairs.get(keyValuePairs.size() - 1).getValue();
-
-        discretizationTransitions.add(new DiscretizationTransition(new NumericDiscretizationOrigin(
-                d_0,
-                d_k),
-                (Double) values[values.length / 2]
-        ));
         double globalAmeva = 0.0;
-
-
-//        Step 2: Consecutive additions of a new boundary which
-//        results in the locally highest value of the Ameva
-//        criterion.
-//
-//
-//        2.1 Initialize k = 1;
-        int k = 1;
-
-//        2.2 Tentatively add an inner boundary, which is not
-//        already in L, from B, and calculate the corresponding
-//        Ameva value.
-//        2.3 After all the tentative additions have been tried,
-//        accept the one with the highest value of Ameva.
-//        2.4 If (Ameva > GlobalAmeva ) then update L with the
-//        accepted boundary in step 2.3 and set
-//        GlobalAmeva = Ameva , else terminate.
-//        2.5 Set k = k + 1 and go to 2.2
-
-        double ameva = createNewCutPoint(0.0);
+        double ameva = createNewCutPoint(globalAmeva);
 
         while(ameva > globalAmeva){
             globalAmeva = ameva;
-            // add new boundary and calculate Ameva
             ameva = createNewCutPoint(globalAmeva);
         }
 
-        Collections.sort(actualCutPoints);
+        if(actualCutPoints.isEmpty()) {
+            List<DiscretizationTransition> discretizationTransitions = new ArrayList<>();
+            discretizationTransitions.add(new Interval(0, keyValuePairs.size() -1, keyValuePairs).toDiscretizationTransition());
+            return discretizationTransitions;
+        }
 
+        Collections.sort(actualCutPoints);
         List<Interval> evaluatedIntervals = getIntervalsFromCutPoints(actualCutPoints);
-//        Output: Discretization scheme L(k).
         return evaluatedIntervals.stream().map(Interval::toDiscretizationTransition).collect(Collectors.toList());
     }
 
+    /**
+     * tentatively adds new cutPoints to the acutalCutpoints and accepts the cutPoints with the highest ameva.
+     * @param currentAmeva ameva of the current actualCutpoints, used to compare to new value
+     * @return the new ameva value, after the best potential cut point has been added to actualCutpoints
+     */
     private double createNewCutPoint(double currentAmeva) {
         double maxAmeva = currentAmeva;
         int maxPos = 0;
-        for(int i = 0; i < B.size(); i++) {
-            double potentialCutPoint = B.get(0);
+        for(int i = 0; i < bCutPoints.size(); i++) {
+            double potentialCutPoint = bCutPoints.get(i);
             double ameva = determineAmeva(potentialCutPoint);
 
             if(ameva > maxAmeva) {
@@ -122,14 +98,20 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
             }
         }
         if(maxAmeva != currentAmeva) {
-            actualCutPoints.add(B.get(maxPos));
-            B.remove(maxPos);
+            actualCutPoints.add(bCutPoints.get(maxPos));
+            bCutPoints.remove(maxPos);
         }
 
         return maxAmeva;
     }
 
-    private double determineAmeva(double potentialCutPoint) {
+    /**
+     * determines the ameva the intervals would have if this cut point would be added. Uses variation of contingency
+     * coefficient.
+     * @param potentialCutPoint double value of new cut point, used to generate Intervals
+     * @return ameva of potential Intervals if cut point would be added
+     */
+    double determineAmeva(double potentialCutPoint) {
         List<Double> potentialCutPoints = new ArrayList<>(actualCutPoints);
         potentialCutPoints.add(potentialCutPoint);
         Collections.sort(potentialCutPoints);
@@ -137,18 +119,22 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 
         double chiSquared = 0.0;
         for(int i = 0; i < targetValues.length; i++){
-            for(int j = 0; j < intervals.size(); j++){
-                double dividend = Math.pow(intervals.get(j).getClassDist()[i], 2);
-                double divisor = targetValueDistribution[i] * intervals.get(j).getSize();
+            for(Interval interval: intervals){
+                double dividend = Math.pow(interval.getClassDist()[i], 2);
+                double divisor = targetValueDistribution[i] * (double) interval.getSize();
                 chiSquared += dividend / divisor;
             }
         }
-        chiSquared = (keyValuePairs.size()) *  (-1 + chiSquared) /* N * ( -1 + chi²) */;
+        chiSquared = (keyValuePairs.size()) *  (-1 + chiSquared);
 
-        double ameva = chiSquared / (intervals.size() * (targetValues.length  - 1)) /*k * (l - 1)*/;
-        return ameva;
+        return chiSquared / (intervals.size() * (targetValues.length  - 1));
     }
 
+    /**
+     * creates {@link Interval} from intervals.
+     * @param cutPoints list of cut points. Have to be in values.
+     * @return list of Intervals
+     */
     private List<Interval> getIntervalsFromCutPoints(List<Double> cutPoints) {
         int lowerBoundary = 0;
         int z = 0;
@@ -157,8 +143,8 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
             while(keyValuePairs.get(z).getKey().doubleValue() < cp && z < keyValuePairs.size()) {
                 z++;
             }
-            createdIntervals.add(new Interval(lowerBoundary, z, keyValuePairs));
-            z = lowerBoundary = z + 1;
+            createdIntervals.add(new Interval(lowerBoundary, z -1, keyValuePairs));
+            lowerBoundary = z ;
         }
         if(createdIntervals.get(createdIntervals.size() -1).getEnd() != keyValuePairs.get(keyValuePairs.size() -1).getKey().doubleValue()) {
             createdIntervals.add(new Interval(lowerBoundary, keyValuePairs.size() - 1, keyValuePairs));

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
@@ -2,12 +2,11 @@ package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
 
 import de.viadee.xai.anchor.adapter.tabular.discretizer.AbstractDiscretizer;
 import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.Interval;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.NumericDiscretizationOrigin;
 
 import java.io.Serializable;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -18,6 +17,11 @@ import java.util.stream.Stream;
 public class AmevaDiscretizer extends AbstractDiscretizer {
 
     private Double[] targetValues;
+    private long[] targetValueDistribution;
+    private List<Double> B = new ArrayList<>();
+    private List<Double> actualCutPoints = new ArrayList<>();
+    private List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs;
+
     /**
      * Constructs the Ameva Discretizer, Ameva works without any Parameters.
      */
@@ -31,12 +35,14 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
         if (Stream.of(values).anyMatch(v -> !(v instanceof Number))) {
             throw new IllegalArgumentException("Only numeric values allowed for this discretizer");
         }
-        List<DiscretizationTransition> discretizationTransitions;
-        List<Double> cutPoints;
+        List<DiscretizationTransition> discretizationTransitions = new ArrayList<>();;
         targetValues = Arrays.stream(labels).sorted().distinct().toArray(Double[]::new);
-
-//        Input: Data consisting of N examples, l classes, and continuous variables X_i
-//        For every X_i do:
+        targetValueDistribution = new long[targetValues.length];
+        for(int i = 0; i < targetValues.length; i++) {
+            int finalI = i;
+            targetValueDistribution[i] = Arrays.stream(labels).filter(label -> label.equals(targetValues[finalI])).count();
+        }
+//        For every continuous variable (X_i) do:
 //
 //        Step 1: Initialization of the candidate interval
 //        boundaries and the initial discretization scheme.
@@ -47,30 +53,37 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 //        boundaries B with the minimum, maximum and all the
 //        midpoints of all the adjacent pairs in the set.
 
-        final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs = IntStream
-                .range(0, values.length)
+        keyValuePairs = IntStream.range(0, values.length)
                 .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>((Number) values[i], labels[i]))
-                .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue())).distinct()
+                .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue()))
                 .collect(Collectors.toList());
 
-
-        final List<Number> B;
-
-
-        Number d_0 = keyValuePairs.get(0).getValue();
-        Number d_k = keyValuePairs.get(keyValuePairs.size() - 1).getValue();
-
-        double ameva, globalAmeva;
-        globalAmeva = 0.0;
+        B = IntStream.range(1, values.length)
+                .mapToObj(i -> ((Double) values[i] + (Double) values[i-1] )/ 2)
+                .sorted().distinct()
+                .collect(Collectors.toList());
 
 //        1.3 Set the initial discretization scheme to
 //        L:{[d_0, d_k]}, set GlobalAmeva = 0.
-//
+        Number d_0 = keyValuePairs.get(0).getValue();
+        Number d_k = keyValuePairs.get(keyValuePairs.size() - 1).getValue();
+
+        discretizationTransitions.add(new DiscretizationTransition(new NumericDiscretizationOrigin(
+                d_0,
+                d_k),
+                (Double) values[values.length / 2]
+        ));
+        double globalAmeva = 0.0;
+
+
 //        Step 2: Consecutive additions of a new boundary which
 //        results in the locally highest value of the Ameva
 //        criterion.
+//
+//
 //        2.1 Initialize k = 1;
         int k = 1;
+
 //        2.2 Tentatively add an inner boundary, which is not
 //        already in L, from B, and calculate the corresponding
 //        Ameva value.
@@ -80,19 +93,81 @@ public class AmevaDiscretizer extends AbstractDiscretizer {
 //        accepted boundary in step 2.3 and set
 //        GlobalAmeva = Ameva , else terminate.
 //        2.5 Set k = k + 1 and go to 2.2
-//        while(ameva > globalAmeva){
-//            double maxAmevaCrit = 0;
-//            // add boundry not in list of boundry from list of candidate and calculate Ameva
-//            k++;
-//            if( k) {
-//            }
-//
-//            cutPoints.add(point);
-//
-//            globalAmeva = ameva;
-//        }
 
+        double ameva = createNewCutPoint(0.0);
+
+        while(ameva > globalAmeva){
+            globalAmeva = ameva;
+            // add new boundary and calculate Ameva
+            ameva = createNewCutPoint(globalAmeva);
+        }
+
+        Collections.sort(actualCutPoints);
+
+        int lowerBoundary = 0;
+        int z = 0;
+        List<Interval> evaluatedIntervals = new ArrayList<>();
+        for(Double cp: actualCutPoints) {
+            while(keyValuePairs.get(z).getKey().doubleValue() < cp && z < keyValuePairs.size()) {
+                z++;
+            }
+            evaluatedIntervals.add(new Interval(lowerBoundary, z, keyValuePairs));
+            z = lowerBoundary = z + 1;
+        }
 //        Output: Discretization scheme L(k).
-        return null;
+        return evaluatedIntervals.stream().map(Interval::toDiscretizationTransition).collect(Collectors.toList());
+    }
+
+    private double createNewCutPoint(double currentAmeva) {
+        double maxAmeva = currentAmeva;
+        int maxPos = 0;
+        for(int i = 0; i < B.size(); i++) {
+            double potentialCutPoint = B.get(0);
+            double ameva = determineAmeva(potentialCutPoint);
+
+            if(ameva > maxAmeva) {
+                maxPos = i;
+                maxAmeva = ameva;
+            }
+        }
+        if(maxAmeva != currentAmeva) {
+            actualCutPoints.add(B.get(maxPos));
+            B.remove(maxPos);
+        }
+
+        return maxAmeva;
+    }
+
+    private double determineAmeva(double potentialCutPoint) {
+        List<Double> potentialCutPoints = new ArrayList<>(actualCutPoints);
+        potentialCutPoints.add(potentialCutPoint);
+        Collections.sort(potentialCutPoints);
+        List<Interval> intervals = new ArrayList<>();
+
+        int lowerBoundary = 0;
+        int z = 0;
+        for(Double cp: potentialCutPoints) {
+            while(keyValuePairs.get(z).getKey().doubleValue() < cp && z < keyValuePairs.size() - 1) {
+                z++;
+            }
+            intervals.add(new Interval(lowerBoundary, z, keyValuePairs));
+            z = lowerBoundary = z + 1;
+        }
+        if(intervals.get(intervals.size() -1).getEnd() != keyValuePairs.get(keyValuePairs.size() -1).getKey().doubleValue()) {
+            intervals.add(new Interval(lowerBoundary, keyValuePairs.size() - 1, keyValuePairs));
+        }
+
+        double chiSquared = 0.0;
+        for(int i = 0; i < targetValues.length; i++){
+            for(int j = 0; j < intervals.size(); j++){
+                double dividend = Math.pow(intervals.get(j).getClassDist()[i], 2);
+                double divisor = targetValueDistribution[i] * intervals.get(j).getSize();
+                chiSquared += dividend / divisor;
+            }
+        }
+        chiSquared = (keyValuePairs.size()) *  (-1 + chiSquared) /* N * ( -1 + chi²) */;
+
+        double ameva = chiSquared / (intervals.size() * (targetValues.length  - 1)) /*k * (l - 1)*/;
+        return ameva;
     }
 }

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizer.java
@@ -1,0 +1,98 @@
+package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
+
+import de.viadee.xai.anchor.adapter.tabular.discretizer.AbstractDiscretizer;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
+
+import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of the FUSINTER discretization algorithm described by [Gonzales-Abril, Cuberos, Velasco, Ortega 2009]
+ */
+public class AmevaDiscretizer extends AbstractDiscretizer {
+
+    private Double[] targetValues;
+    /**
+     * Constructs the Ameva Discretizer, Ameva works without any Parameters.
+     */
+    public AmevaDiscretizer() {
+        super(true);
+    }
+
+    @Override
+    protected List<DiscretizationTransition> fitCreateTransitions(Serializable[] values, Double[] labels) {
+
+        if (Stream.of(values).anyMatch(v -> !(v instanceof Number))) {
+            throw new IllegalArgumentException("Only numeric values allowed for this discretizer");
+        }
+        List<DiscretizationTransition> discretizationTransitions;
+        List<Double> cutPoints;
+        targetValues = Arrays.stream(labels).sorted().distinct().toArray(Double[]::new);
+
+//        Input: Data consisting of N examples, l classes, and continuous variables X_i
+//        For every X_i do:
+//
+//        Step 1: Initialization of the candidate interval
+//        boundaries and the initial discretization scheme.
+
+//        1.1 Find the maximum (d_k) and minimum (d_0) values of X_i.
+//        1.2 Form a set of all distinct values of X_i, in ascending
+//        order, and initialize all possible interval
+//        boundaries B with the minimum, maximum and all the
+//        midpoints of all the adjacent pairs in the set.
+
+        final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs = IntStream
+                .range(0, values.length)
+                .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>((Number) values[i], labels[i]))
+                .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue())).distinct()
+                .collect(Collectors.toList());
+
+
+        final List<Number> B;
+
+
+        Number d_0 = keyValuePairs.get(0).getValue();
+        Number d_k = keyValuePairs.get(keyValuePairs.size() - 1).getValue();
+
+        double ameva, globalAmeva;
+        globalAmeva = 0.0;
+
+//        1.3 Set the initial discretization scheme to
+//        L:{[d_0, d_k]}, set GlobalAmeva = 0.
+//
+//        Step 2: Consecutive additions of a new boundary which
+//        results in the locally highest value of the Ameva
+//        criterion.
+//        2.1 Initialize k = 1;
+        int k = 1;
+//        2.2 Tentatively add an inner boundary, which is not
+//        already in L, from B, and calculate the corresponding
+//        Ameva value.
+//        2.3 After all the tentative additions have been tried,
+//        accept the one with the highest value of Ameva.
+//        2.4 If (Ameva > GlobalAmeva ) then update L with the
+//        accepted boundary in step 2.3 and set
+//        GlobalAmeva = Ameva , else terminate.
+//        2.5 Set k = k + 1 and go to 2.2
+//        while(ameva > globalAmeva){
+//            double maxAmevaCrit = 0;
+//            // add boundry not in list of boundry from list of candidate and calculate Ameva
+//            k++;
+//            if( k) {
+//            }
+//
+//            cutPoints.add(point);
+//
+//            globalAmeva = ameva;
+//        }
+
+//        Output: Discretization scheme L(k).
+        return null;
+    }
+}

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizer.java
@@ -101,12 +101,14 @@ public class FUSINTERDiscretizer extends AbstractDiscretizer {
             } else {
                 amountSameValue++;
                 if (!currentValue.equals(keyValuePairs.get(i - amountSameValue).getValue())) {
-                    if (resultDiscTrans.get(resultDiscTrans.size() - 1).getEnd() != i - amountSameValue - 1) {
+                    if ( !resultDiscTrans.isEmpty() && resultDiscTrans.get(resultDiscTrans.size() - 1).getEnd() != i - amountSameValue - 1) {
                         resultDiscTrans.add(new Interval(lowerLimit, i - 1 - amountSameValue, keyValuePairs));
                     }
                     lowerLimit = i - amountSameValue;
                     i++;
-
+                    if(i == keyValuePairs.size()){
+                        break;
+                    }
                     while (keyValuePairs.get(i).getKey().equals(keyValuePairs.get(i - 1).getKey())) {
                         i++;
                     }

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizer.java
@@ -42,12 +42,12 @@ public class FUSINTERDiscretizer extends AbstractDiscretizer {
         this.alpha = alpha;
     }
 
-    /*
+    /**
      *
      * Implementation of FUSINTER, 1. sort, 2. equalClassIntervals 3. merge if entropy improves
      *
-     * @param values array of arrays of type {Number, int}, 1. is the column to be discretized
-     *               and 2. is the classification
+     * @param labels Array of Doubles, classifications of instances
+     * @param values Array of Numbers expected. FUSINTER is only possible with continuous variables
      * @return list of Intervals determined to have the highest entropy
      */
     @Override

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizer.java
@@ -60,9 +60,9 @@ public class FUSINTERDiscretizer extends AbstractDiscretizer {
         m = Arrays.stream(labels).sorted().distinct().toArray(Double[]::new).length;
         n = values.length;
 
-        final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs = IntStream
+        final List<AbstractMap.SimpleImmutableEntry<Double, Double>> keyValuePairs = IntStream
                 .range(0, values.length)
-                .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>((Number) values[i], labels[i]))
+                .mapToObj(i -> new AbstractMap.SimpleImmutableEntry<>((Double) values[i], labels[i]))
                 .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue()))
                 .collect(Collectors.toList());
 
@@ -80,7 +80,7 @@ public class FUSINTERDiscretizer extends AbstractDiscretizer {
      * @param keyValuePairs, Array of Attribute Class.
      * @return initial List of Intervals
      */
-    List<Interval> equalClassSplit(final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs) {
+    List<Interval> equalClassSplit(final List<AbstractMap.SimpleImmutableEntry<Double, Double>> keyValuePairs) {
         final List<Interval> resultDiscTrans = new ArrayList<>();
         int lowerLimit = 0;
         int amountSameValue = 0;
@@ -121,7 +121,7 @@ public class FUSINTERDiscretizer extends AbstractDiscretizer {
     }
 
     private List<Interval> evaluateIntervals(List<Interval> equalClassSplits,
-                                             final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs) {
+                                             final List<AbstractMap.SimpleImmutableEntry<Double, Double>> keyValuePairs) {
         boolean improvement = true;
 
         while (equalClassSplits.size() > 1 && improvement) {
@@ -179,7 +179,7 @@ public class FUSINTERDiscretizer extends AbstractDiscretizer {
      * @return new List with Interval i and i+1 merged
      */
     private List<Interval> mergeInterval(List<Interval> intervals, int i,
-                                         final List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs) {
+                                         final List<AbstractMap.SimpleImmutableEntry<Double, Double>> keyValuePairs) {
         List<Interval> temp = new ArrayList<>(intervals.subList(0, intervals.size()));
         int mergeBegin = temp.get(i).getBegin();
         int mergeEnd = temp.get(i + 1).getEnd();

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/TabularInstanceVisualizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/TabularInstanceVisualizerTest.java
@@ -71,7 +71,7 @@ class TabularInstanceVisualizerTest {
         String visualization = tabularInstanceVisualizer.visualizeResult(result);
         
         String expected = "IF name = 'testrow2' {0.1, -0.19} AND " + System.lineSeparator() +
-                "numAttr IN [10, 20) {0.2, -0.2} AND " + System.lineSeparator() +
+                "numAttr IN ]10, 20[ {0.2, -0.2} AND " + System.lineSeparator() +
                 "attr3 = 'thirdattr2' {0.2, -0.19} AND " + System.lineSeparator() +
                 "attr2 = 'anotherattr2' {0.5, -0.2}" + System.lineSeparator() +
                 "THEN PREDICT [someattr2] (1)" + System.lineSeparator() +

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
@@ -1,15 +1,21 @@
 package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
 
+import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.NumericDiscretizationOrigin;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class AmevaDiscretizerTest {
 
     @Test
-    void AmevaStepOneTest(){
+    void AmevaTestBasicDiscretization(){
         Number[][] values = new Number[][]{
                 {1.0, 0},
                 {2.0, 0},
@@ -32,6 +38,192 @@ class AmevaDiscretizerTest {
 
 
         amevaDiscretizer.fit(serializables, doubles);
-        assertEquals(1, 1);
+        List<DiscretizationTransition> list = new ArrayList<>(amevaDiscretizer.getTransitions());
+
+        NumericDiscretizationOrigin discOrigin = ((NumericDiscretizationOrigin) list.get(0).getDiscretizationOrigin());
+        assertEquals(1D, discOrigin.getMinValue());
+        assertEquals(5D, discOrigin.getMaxValue());
+        assertEquals(3.0, list.get(0).getDiscretizedValue().doubleValue());
+        assertTrue(discOrigin.isFirst());
+        assertFalse(discOrigin.isLast());
+
+        NumericDiscretizationOrigin discOrigin2 = ((NumericDiscretizationOrigin) list.get(1).getDiscretizationOrigin());
+        assertEquals(6D, discOrigin2.getMinValue());
+        assertEquals(10D, discOrigin2.getMaxValue());
+        assertEquals(8.0, list.get(1).getDiscretizedValue().doubleValue());
+        assertFalse(discOrigin2.isFirst());
+        assertTrue(discOrigin2.isLast());
     }
+
+    @Test
+    void AmevaTestNoDiscretization(){
+        Number[][] values = new Number[][]{
+                {1.0, 0},
+                {2.0, 0},
+                {3.0, 0},
+                {4.0, 0},
+                {5.0, 0},
+                {6.0, 0},
+                {7.0, 0},
+                {8.0, 0},
+                {9.0, 0},
+                {10.0, 0}
+        };
+        Serializable[] serializables = new Serializable[values.length];
+        Double[] doubles = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            serializables[i] = values[i][0];
+            doubles[i] = values[i][1].doubleValue();
+        }
+        AmevaDiscretizer amevaDiscretizer = new AmevaDiscretizer();
+
+
+        amevaDiscretizer.fit(serializables, doubles);
+        List<DiscretizationTransition> list = new ArrayList<>(amevaDiscretizer.getTransitions());
+
+        NumericDiscretizationOrigin discOrigin = ((NumericDiscretizationOrigin) list.get(0).getDiscretizationOrigin());
+        assertEquals(1D, discOrigin.getMinValue());
+        assertEquals(10D, discOrigin.getMaxValue());
+        assertEquals(5.5, list.get(0).getDiscretizedValue().doubleValue());
+        assertTrue(discOrigin.isFirst());
+        assertTrue(discOrigin.isLast());
+    }
+
+    @Test
+    void testAmevaBasicNonBinaryClassification(){
+        Number[][] values = new Number[][]{
+                {1.0, 0},
+                {2.0, 0},
+                {3.0, 0},
+                {4.0, 0},
+                {5.0, 0},
+                {6.0, 1},
+                {7.0, 1},
+                {8.0, 1},
+                {9.0, 1},
+                {10.0, 1},
+                {11.0, 2},
+                {12.0, 2},
+                {13.0, 2},
+                {14.0, 2},
+                {15.0, 2},
+        };
+        Serializable[] serializables = new Serializable[values.length];
+        Double[] doubles = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            serializables[i] = values[i][0];
+            doubles[i] = values[i][1].doubleValue();
+        }
+        AmevaDiscretizer amevaDiscretizer = new AmevaDiscretizer();
+
+
+        amevaDiscretizer.fit(serializables, doubles);
+        List<DiscretizationTransition> list = new ArrayList<>(amevaDiscretizer.getTransitions());
+
+        NumericDiscretizationOrigin discOrigin = ((NumericDiscretizationOrigin) list.get(2).getDiscretizationOrigin());
+        assertEquals(11D, discOrigin.getMinValue());
+        assertEquals(15D, discOrigin.getMaxValue());
+        assertEquals(13.0, list.get(2).getDiscretizedValue().doubleValue());
+        assertFalse(discOrigin.isFirst());
+        assertTrue(discOrigin.isLast());
+    }
+
+    @Test
+    void testEqualDistribution() {
+        Number[][] values = new Number[][]{
+                {1.0, 1},
+                {1.0, 0},
+                {2.0, 1},
+                {2.0, 0},
+                {3.0, 1},
+                {3.0, 0},
+                {4.0, 1},
+                {4.0, 0}
+        };
+        Serializable[] serializables = new Serializable[values.length];
+        Double[] doubles = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            serializables[i] = values[i][0];
+            doubles[i] = values[i][1].doubleValue();
+        }
+
+        AmevaDiscretizer amevaDiscretizer = new AmevaDiscretizer();
+        List<DiscretizationTransition> list = amevaDiscretizer.fitCreateTransitions(serializables, doubles);
+        assertEquals(1, list.size());
+    }
+
+    @Test
+    void testAmevaValueDetermination() throws Exception {
+        Number[][] values = new Number[][]{
+                {1.0, 0},
+                {2.0, 0},
+                {3.0, 1},
+                {4.0, 1},
+                {5.0, 1},
+                {6.0, 1},
+                {7.0, 1},
+                {8.0, 0},
+                {9.0, 0},
+                {10.0, 0},
+                {11.0, 1},
+                {12.0, 1},
+                {13.0, 1},
+                {14.0, 0},
+                {15.0, 0},
+                {16.0, 0},
+                {17.0, 0},
+                {18.0, 0},
+                {19.0, 0},
+                {20.0, 1},
+                {21.0, 1},
+                {22.0, 1},
+                {23.0, 1},
+                {24.0, 1},
+                {25.0, 0},
+                {26.0, 1},
+                {27.0, 0},
+                {28.0, 0},
+                {29.0, 0},
+                {30.0, 0}
+        };
+        AmevaDiscretizer amevaDiscretizer = new AmevaDiscretizer();
+        List<AbstractMap.SimpleImmutableEntry<Number, Double>> keyValuePairs = Arrays.stream(values).map(value -> new AbstractMap.SimpleImmutableEntry<>((Number) value[0], value[1].doubleValue()))
+                .sorted(Comparator.comparing(entry -> entry.getKey().doubleValue()))
+                .collect(Collectors.toList());
+
+        Field keyValuePairsField = AmevaDiscretizer.class.getDeclaredField("keyValuePairs");
+        keyValuePairsField.setAccessible(true);
+        keyValuePairsField.set(amevaDiscretizer, keyValuePairs);
+
+        List<Double> actualCutPoints = new ArrayList<>();
+        actualCutPoints.add(7.5);
+        actualCutPoints.add(19.5);
+
+        Field actualCutPointsField = AmevaDiscretizer.class.getDeclaredField("actualCutPoints");
+        actualCutPointsField.setAccessible(true);
+        actualCutPointsField.set(amevaDiscretizer, actualCutPoints);
+
+        Double[] targetValues = new Double[2];
+        targetValues[0] = 0.0;
+        targetValues[1] = 1.0;
+
+        Field targetValuesField = AmevaDiscretizer.class.getDeclaredField("targetValues");
+        targetValuesField.setAccessible(true);
+        targetValuesField.set(amevaDiscretizer, targetValues);
+
+        long[] targetValueDistribution = new long[2];
+        targetValueDistribution[0] = 17;
+        targetValueDistribution[1] = 13;
+
+        Field targetValueDistributionField = AmevaDiscretizer.class.getDeclaredField("targetValueDistribution");
+        targetValueDistributionField.setAccessible(true);
+        targetValueDistributionField.set(amevaDiscretizer, targetValueDistribution);
+
+
+        double ameva = amevaDiscretizer.determineAmeva(24.5);
+
+        assertEquals(3.04, ameva, 0.01);
+
+    }
+
 }

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
@@ -2,14 +2,36 @@ package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AmevaDiscretizerTest {
 
     @Test
     void AmevaStepOneTest(){
+        Number[][] values = new Number[][]{
+                {1.0, 0},
+                {2.0, 0},
+                {3.0, 0},
+                {4.0, 0},
+                {5.0, 0},
+                {6.0, 1},
+                {7.0, 1},
+                {8.0, 1},
+                {9.0, 1},
+                {10.0, 1}
+        };
+        Serializable[] serializables = new Serializable[values.length];
+        Double[] doubles = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            serializables[i] = values[i][0];
+            doubles[i] = values[i][1].doubleValue();
+        }
         AmevaDiscretizer amevaDiscretizer = new AmevaDiscretizer();
 
+
+        amevaDiscretizer.fit(serializables, doubles);
         assertEquals(1, 1);
     }
 }

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/AmevaDiscretizerTest.java
@@ -1,0 +1,15 @@
+package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AmevaDiscretizerTest {
+
+    @Test
+    void AmevaStepOneTest(){
+        AmevaDiscretizer amevaDiscretizer = new AmevaDiscretizer();
+
+        assertEquals(1, 1);
+    }
+}

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizerTest.java
@@ -1,11 +1,11 @@
 package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
 
 import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.Interval;
 import de.viadee.xai.anchor.adapter.tabular.discretizer.NumericDiscretizationOrigin;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
-import java.lang.reflect.Field;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,12 +32,9 @@ class FUSINTERDiscretizerTest {
      * Tests Step 2 (Initial Splitting) of FUSINTER Algorithm
      */
     @Test
-    void testEqualClassSplittingSeparateClasses() throws Exception {
+    void testEqualClassSplittingSeparateClasses() {
         FUSINTERDiscretizer fusinterDiscretizer = new FUSINTERDiscretizer();
-        Field targetValues = FUSINTERDiscretizer.class.getDeclaredField("targetValues");
-        targetValues.setAccessible(true);
-        targetValues.set(fusinterDiscretizer, new Double[]{0.0, 1.0});
-        List<FUSINTERDiscretizer.Interval> list = fusinterDiscretizer.equalClassSplit(
+        List<Interval> list = fusinterDiscretizer.equalClassSplit(
                 Arrays.asList(
                         new AbstractMap.SimpleImmutableEntry<>(0.0, 0.0),
                         new AbstractMap.SimpleImmutableEntry<>(1.0, 0.0),
@@ -59,12 +56,9 @@ class FUSINTERDiscretizerTest {
      * Tests Step 3 (Values with Mixed Classes Have own Interval) of FUSINTER Algorithm
      */
     @Test
-    void testEqualClassSplittingMixedClasses() throws Exception {
+    void testEqualClassSplittingMixedClasses() {
         FUSINTERDiscretizer fusinterDiscretizer = new FUSINTERDiscretizer();
-        Field targetValues = FUSINTERDiscretizer.class.getDeclaredField("targetValues");
-        targetValues.setAccessible(true);
-        targetValues.set(fusinterDiscretizer, new Double[]{0.0, 1.0});
-        List<FUSINTERDiscretizer.Interval> list = fusinterDiscretizer.equalClassSplit(
+        List<Interval> list = fusinterDiscretizer.equalClassSplit(
                 Arrays.asList(
                         new AbstractMap.SimpleImmutableEntry<>(0.0, 0.0),
                         new AbstractMap.SimpleImmutableEntry<>(1.0, 0.0),

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizerTest.java
@@ -39,17 +39,17 @@ class FUSINTERDiscretizerTest {
         targetValues.set(fusinterDiscretizer, new Double[]{0.0, 1.0});
         List<FUSINTERDiscretizer.Interval> list = fusinterDiscretizer.equalClassSplit(
                 Arrays.asList(
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(0.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(1.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(2.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(3.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(4.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(5.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(6.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(7.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(8.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(9.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(0.0, 0.0)
+                        new AbstractMap.SimpleImmutableEntry<>(0.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(1.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(2.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(3.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(4.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(5.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(6.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(7.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(8.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(9.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(0.0, 0.0)
                 )
         );
         assertEquals(3, list.size());
@@ -66,19 +66,19 @@ class FUSINTERDiscretizerTest {
         targetValues.set(fusinterDiscretizer, new Double[]{0.0, 1.0});
         List<FUSINTERDiscretizer.Interval> list = fusinterDiscretizer.equalClassSplit(
                 Arrays.asList(
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(0.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(1.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(2.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(3.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(4.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(5.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(5.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(5.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(6.0, 1.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(7.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(8.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(9.0, 0.0),
-                        new AbstractMap.SimpleImmutableEntry<Number, Double>(0.0, 0.0)
+                        new AbstractMap.SimpleImmutableEntry<>(0.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(1.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(2.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(3.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(4.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(5.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(5.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(5.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(6.0, 1.0),
+                        new AbstractMap.SimpleImmutableEntry<>(7.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(8.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(9.0, 0.0),
+                        new AbstractMap.SimpleImmutableEntry<>(0.0, 0.0)
                 )
         );
         assertEquals(5, list.size());
@@ -292,4 +292,31 @@ class FUSINTERDiscretizerTest {
 
     }
 
+    /**
+     * Tests Steps 4-8 (Evaluation of potential merges of the equalClassSplits) of the described Algorithm,
+     * Number[][] to be discretized is taken from FUSINTER paper Figure 7.
+     */
+    @Test
+    void testIntervalReductionColin() {
+        Number[][] values = new Number[][]{
+                {1.0, 1},
+                {1.0, 0},
+                {2.0, 1},
+                {2.0, 0},
+                {3.0, 1},
+                {3.0, 0},
+                {4.0, 1},
+                {4.0, 0}
+        };
+        Serializable[] serializables = new Serializable[values.length];
+        Double[] doubles = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            serializables[i] = values[i][0];
+            doubles[i] = values[i][1].doubleValue();
+        }
+
+        FUSINTERDiscretizer fusinterDiscretizer = new FUSINTERDiscretizer();
+        List<DiscretizationTransition> list = fusinterDiscretizer.fitCreateTransitions(serializables, doubles);
+        assertEquals(1, list.size());
+    }
 }

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/FUSINTERDiscretizerTest.java
@@ -273,7 +273,7 @@ class FUSINTERDiscretizerTest {
         NumericDiscretizationOrigin discOrigin3 = ((NumericDiscretizationOrigin) list.get(3).getDiscretizationOrigin());
         assertEquals(23D, discOrigin3.getMinValue());
         assertEquals(36D, discOrigin3.getMaxValue());
-        assertEquals(31.0, list.get(3).getDiscretizedValue().doubleValue());
+        assertEquals(30.0, list.get(3).getDiscretizedValue().doubleValue());
         assertFalse(discOrigin3.isFirst());
         assertFalse(discOrigin3.isLast());
 
@@ -291,7 +291,7 @@ class FUSINTERDiscretizerTest {
      * Number[][] to be discretized is taken from FUSINTER paper Figure 7.
      */
     @Test
-    void testIntervalReductionColin() {
+    void testEqualDistribution() {
         Number[][] values = new Number[][]{
                 {1.0, 1},
                 {1.0, 0},


### PR DESCRIPTION
Added a second supervised discretizer, Ameva. Unlike the FUSINTER discretization, this algorithm uses a variation of the contingency coefficents. Also Ameva starts with 0 cut points and tentatively tests if an additional cut point would increase the coefficent.

Small refactoring of Interval and AbstractDiscretizer were needed. Also small bugs in FUSINTER were fixed. 