### PR TITLE
Added an unsupervised & non-parameterized Discretizer PKID

### DIFF
--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/EqualSizeDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/EqualSizeDiscretizer.java
@@ -1,0 +1,50 @@
+package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
+
+import de.viadee.xai.anchor.adapter.tabular.discretizer.AbstractDiscretizer;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Implementation of the PKID and ESD discretization algorithms described by [Yang and Webb 2009]
+ */
+public class EqualSizeDiscretizer extends AbstractDiscretizer {
+
+    private int classSize;
+
+    /**
+     * creates a {@link PercentileMedianDiscretizer} which creates intervals, that are the same size as there are
+     * number of intervals
+     */
+    public EqualSizeDiscretizer() {
+        this(0);
+    }
+
+    /**
+     * creates a {@link PercentileMedianDiscretizer} which creates intervals, that are the same size. In actual datasets
+     * a minimum size of 30 is recommended by [Weiss, 2002]
+     */
+    public EqualSizeDiscretizer(int classSize) {
+        super(false);
+        this.classSize = classSize;
+    }
+
+    /**
+     * creates the {@link DiscretizationTransition} of the values. Each transition will have the same size. If no size
+     * is given as a parameter in the constructor, a PKID will be created.
+     * @param values the values to be fitted on
+     * @param labels the labels. != null, iff supervised
+     * @return list of Transisitions, created by {@link PercentileMedianDiscretizer}. All will have the same length.
+     */
+    @Override
+    protected List<DiscretizationTransition> fitCreateTransitions(Serializable[] values, Double[] labels) {
+        if(classSize == 0) {
+            classSize = (int) Math.sqrt(values.length);
+        } else if (classSize >= values.length) {
+            classSize = values.length;
+        }
+        PercentileMedianDiscretizer percentileMedianDiscretizer = new PercentileMedianDiscretizer((values.length/ classSize));
+        return percentileMedianDiscretizer.fitCreateTransitions(values, null);
+    }
+}

--- a/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/EqualSizeDiscretizer.java
+++ b/DefaultConfigsExtension/src/main/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/EqualSizeDiscretizer.java
@@ -24,6 +24,7 @@ public class EqualSizeDiscretizer extends AbstractDiscretizer {
     /**
      * creates a {@link PercentileMedianDiscretizer} which creates intervals, that are the same size. In actual datasets
      * a minimum size of 30 is recommended by [Weiss, 2002]
+     * @param classSize size of Intervals to be created. Might be changed slightly if values length is not divisible by it
      */
     public EqualSizeDiscretizer(int classSize) {
         super(false);

--- a/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/EqualSizeDiscretizerTest.java
+++ b/DefaultConfigsExtension/src/test/java/de/viadee/xai/anchor/adapter/tabular/discretizer/impl/EqualSizeDiscretizerTest.java
@@ -1,0 +1,115 @@
+package de.viadee.xai.anchor.adapter.tabular.discretizer.impl;
+
+import de.viadee.xai.anchor.adapter.tabular.discretizer.DiscretizationTransition;
+import de.viadee.xai.anchor.adapter.tabular.discretizer.NumericDiscretizationOrigin;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EqualSizeDiscretizerTest {
+
+    @Test
+    void testPKIDForSimpleValues(){
+        Number[] values = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+        };
+
+        EqualSizeDiscretizer equalSizeDiscretizer = new EqualSizeDiscretizer();
+        equalSizeDiscretizer.fit(values);
+        Collection<DiscretizationTransition> transitionList = equalSizeDiscretizer.getTransitions();
+
+        assertEquals(4, transitionList.size());
+    }
+
+    @Test
+    void testPKIDWithReduction(){
+        Number[] values = {
+                0, 0, 0, 0, 0, 0, 0, 0, 8, 9, 10, 11, 12, 13, 14, 15
+        };
+
+        EqualSizeDiscretizer equalSizeDiscretizer = new EqualSizeDiscretizer();
+        equalSizeDiscretizer.fit(values);
+        Collection<DiscretizationTransition> transitionList = equalSizeDiscretizer.getTransitions();
+
+        assertEquals(3, transitionList.size());
+    }
+
+    @Test
+    void testESDForSimpleValues(){
+        Number[] values = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        };
+
+        EqualSizeDiscretizer equalSizeDiscretizer = new EqualSizeDiscretizer(5);
+        equalSizeDiscretizer.fit(values);
+        Collection<DiscretizationTransition> transitionList = equalSizeDiscretizer.getTransitions();
+
+        assertEquals(2, transitionList.size());
+    }
+
+    @Test
+    void testESDWithClassSizeHigherThanLength(){
+        Number[] values = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        };
+
+        EqualSizeDiscretizer equalSizeDiscretizer = new EqualSizeDiscretizer(100);
+        equalSizeDiscretizer.fit(values);
+        Collection<DiscretizationTransition> transitionList = equalSizeDiscretizer.getTransitions();
+
+        assertEquals(1, transitionList.size());
+    }
+
+    @Test
+    void testESDWithClassSizeNegative(){
+        Number[] values = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+        };
+
+        EqualSizeDiscretizer equalSizeDiscretizer = new EqualSizeDiscretizer(-5);
+        equalSizeDiscretizer.fit(values);
+        Collection<DiscretizationTransition> transitionList = equalSizeDiscretizer.getTransitions();
+
+        assertEquals(0, transitionList.size());
+    }
+
+    @Test
+    void testESD(){
+        Number[] values = {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+                10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                20, 21, 22, 23, 24, 25, 26, 27, 28, 29
+        };
+
+        EqualSizeDiscretizer equalSizeDiscretizer = new EqualSizeDiscretizer(5);
+        equalSizeDiscretizer.fit(values);
+
+        List<DiscretizationTransition> list = new ArrayList<>(equalSizeDiscretizer.getTransitions());
+
+        NumericDiscretizationOrigin discOrigin = ((NumericDiscretizationOrigin) list.get(0).getDiscretizationOrigin());
+        assertEquals(0D, discOrigin.getMinValue());
+        assertEquals(4D, discOrigin.getMaxValue());
+        assertEquals(2D, list.get(0).getDiscretizedValue().doubleValue());
+        assertTrue(discOrigin.isFirst());
+        assertFalse(discOrigin.isLast());
+
+        NumericDiscretizationOrigin discOrigin1 = ((NumericDiscretizationOrigin) list.get(1).getDiscretizationOrigin());
+        assertEquals(5D, discOrigin1.getMinValue());
+        assertEquals(9D, discOrigin1.getMaxValue());
+        assertEquals(7D, list.get(1).getDiscretizedValue().doubleValue());
+        assertFalse(discOrigin1.isFirst());
+        assertFalse(discOrigin1.isLast());
+
+        NumericDiscretizationOrigin discOrigin5 = ((NumericDiscretizationOrigin) list.get(5).getDiscretizationOrigin());
+        assertEquals(25D, discOrigin5.getMinValue());
+        assertEquals(29D, discOrigin5.getMaxValue());
+        assertEquals(27D, list.get(5).getDiscretizedValue().doubleValue());
+        assertFalse(discOrigin5.isFirst());
+        assertTrue(discOrigin5.isLast());
+    }
+
+}


### PR DESCRIPTION
This discretizer is created in response to #29. It is the Proportional k-Interval Discretizer (PKID) (http://users.monash.edu/~webb/Files/YangWebb03b.pdf). The user gives a desired size of each interval and this calls the PercentileMedianDiscretizer with the aquivalent classCount. If no size is given by the user the defaultsize is used, which is the squareroot of the length of the values. 